### PR TITLE
add eut to the dsl

### DIFF
--- a/modules/kernel/src/main/java/com/thegoate/Goate.java
+++ b/modules/kernel/src/main/java/com/thegoate/Goate.java
@@ -124,14 +124,16 @@ public class Goate {
     }
 
     public Object processDSL(Object value) {
-        String check = "" + value;
-        if (check.contains("::")) {
-            check = check.substring(0, check.indexOf("::"));
-        } else {
-            check = null;
-        }
-        if (check != null) {
-            value = dictionary.translate(check, value);
+        if(value!=null) {
+            String check = "" + value;
+            if (check.contains("::")) {
+                check = check.substring(0, check.indexOf("::"));
+            } else {
+                check = null;
+            }
+            if (check != null) {
+                value = dictionary.translate(check, value);
+            }
         }
         return value;
     }

--- a/modules/kernel/src/main/java/com/thegoate/data/PropertyFileDL.java
+++ b/modules/kernel/src/main/java/com/thegoate/data/PropertyFileDL.java
@@ -44,7 +44,7 @@ public class PropertyFileDL extends DataLoader {
     @Override
     public List<Goate> load() {
         List<Goate> data = new ArrayList<>();
-        String pf = new GetFileAsString().from(parameters.get("file"));
+        String pf = new GetFileAsString(parameters.get("file")).from("file::");
         Goate props = new Goate();
         if(pf!=null&&!pf.isEmpty()) {
             pf = pf.replace("\n\r","\r").replace("\r","\n");

--- a/modules/kernel/src/main/java/com/thegoate/dsl/DSL.java
+++ b/modules/kernel/src/main/java/com/thegoate/dsl/DSL.java
@@ -62,7 +62,7 @@ public abstract class DSL {
     }
 
     protected Object get(int index, Goate data){
-        Object o = data.get(definition.get(index), null);
+        Object o = data.processDSL(definition.get(index));
         return o==null?definition.get(index):o;
     }
 

--- a/modules/kernel/src/main/java/com/thegoate/dsl/words/EutConfigDSL.java
+++ b/modules/kernel/src/main/java/com/thegoate/dsl/words/EutConfigDSL.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017. Eric Angeli
+ *
+ *  Permission is hereby granted, free of charge,
+ *  to any person obtaining a copy of this software
+ *  and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction,
+ *  including without limitation the rights to use, copy,
+ *  modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit
+ *  persons to whom the Software is furnished to do so,
+ *  subject to the following conditions:
+ *
+ *  The above copyright notice and this permission
+ *  notice shall be included in all copies or substantial
+ *  portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ *  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ *  AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ */
+
+package com.thegoate.dsl.words;
+
+import com.thegoate.Goate;
+import com.thegoate.data.PropertyFileDL;
+import com.thegoate.dsl.DSL;
+import com.thegoate.dsl.GoateDSL;
+
+import java.util.List;
+
+/**
+ * Checks for a properties file in a folder called eut
+ * whith a file name using the pattern eut.properties, where env is set or passed as a system property or environment
+ * variable where eut is replaced with the name of the environment under test.<br>
+ * example: -Deut=local<br>
+ *      then in the resource directory:<br>
+ *          resources/eut/local.properties<br>
+ * You can override the properties file by setting the same parameter in your run data.
+ * Created by gtque on 5/19/2017.
+ */
+@GoateDSL(word = "eut")
+public class EutConfigDSL extends DSL {
+    public EutConfigDSL(Object value) {
+        super(value);
+    }
+
+    @Override
+    public Object evaluate(Goate data) {
+        Goate eutConfig = (Goate)data.get("_goate_:eutConfig", new Goate());
+        if(eutConfig==null||eutConfig.size()==0) {
+            String eut = "" + data.get("eut", "local");
+            List<Goate> d = new PropertyFileDL().file("eut/"+eut+".properties").load();
+            if(d!=null&&d.size()>0){
+                eutConfig = d.get(0);
+                data.put("_goate_:eutConfig", eutConfig);
+            }
+        }
+        String key = ""+get(1,data);
+        return data.get(key, eutConfig!=null?eutConfig.get(key):null);
+    }
+}

--- a/modules/kernel/src/main/java/com/thegoate/expect/ExpectationThreadBuilder.java
+++ b/modules/kernel/src/main/java/com/thegoate/expect/ExpectationThreadBuilder.java
@@ -58,6 +58,19 @@ public class ExpectationThreadBuilder {
         this.data = data;
     }
 
+    public ExpectationThreadBuilder expect(Goate expectations){
+        if(expectations!=null){
+            for(String key:expectations.keys()){
+                if(expectations.get(key) instanceof String) {
+                    expect("" + expectations.get(key));
+                }else if(expectations.get(key) instanceof Expectation){
+                    expect((Expectation)expectations.get(key));
+                }
+            }
+        }
+        return this;
+    }
+    
     public ExpectationThreadBuilder expect(String definition){
         return expect(new Expectation(data).define(definition));
     }

--- a/modules/kernel/src/main/java/com/thegoate/utils/Utility.java
+++ b/modules/kernel/src/main/java/com/thegoate/utils/Utility.java
@@ -24,15 +24,11 @@
  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  *  DEALINGS IN THE SOFTWARE.
  */
-
-package com.thegoate.utils.get;
-
-import com.thegoate.utils.Utility;
+package com.thegoate.utils;
 
 /**
- * Defines the interface for a get utility.
- * Created by Eric Angeli on 5/5/2017.
+ * Created by Eric Angeli on 5/19/2017.
  */
-public interface GetUtility extends Utility {
-    Object from(Object container);
+public interface Utility {
+    boolean isType(Object check);
 }

--- a/modules/kernel/src/test/java/com/thegoate/dsl/words/EutConfigTests.java
+++ b/modules/kernel/src/test/java/com/thegoate/dsl/words/EutConfigTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017. Eric Angeli
+ *
+ *  Permission is hereby granted, free of charge,
+ *  to any person obtaining a copy of this software
+ *  and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction,
+ *  including without limitation the rights to use, copy,
+ *  modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit
+ *  persons to whom the Software is furnished to do so,
+ *  subject to the following conditions:
+ *
+ *  The above copyright notice and this permission
+ *  notice shall be included in all copies or substantial
+ *  portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ *  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ *  AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ */
+package com.thegoate.dsl.words;
+
+import com.thegoate.Goate;
+import com.thegoate.testng.TestNGEngineAnnotatedDL;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test loading of eut configs.
+ * Created by Eric Angeli on 5/19/2017.
+ */
+public class EutConfigTests extends TestNGEngineAnnotatedDL {
+
+    @Test(groups = {"unit"})
+    public void loadLocalByDefault(){
+        Goate d = new Goate().put("test", "eut::hello");
+        String actual = ""+ d.get("test", "foobar");
+        assertEquals(actual, "world!");
+        assertEquals(d.get("test", "foobar"), "world!");
+    }
+
+    @Test(groups = {"unit"})
+    public void loadLocalOverride(){
+        Goate d = new Goate().put("eut", "local").put("test", "eut::hello").put("hello","chocolate");
+        String actual = ""+ d.get("test", "foobar");
+        assertEquals(actual, "chocolate");
+        assertEquals(d.get("test", "foobar"), "chocolate");
+    }
+
+    @Test(groups = {"unit"})
+    public void loadDooda(){
+        Goate d = new Goate().put("eut", "dooda").put("test", "eut::hello");
+        String actual = ""+ d.get("test", "foobar");
+        assertEquals(actual, "dooda!");
+        assertEquals(d.get("test", "foobar"), "dooda!");
+    }
+}

--- a/modules/kernel/src/test/resources/eut/dooda.properties
+++ b/modules/kernel/src/test/resources/eut/dooda.properties
@@ -1,0 +1,1 @@
+hello=dooda!


### PR DESCRIPTION
eut can be used to get a value from an environment specific property
file located in the eut folder. The value can be overrided in the run
data or system/environment property